### PR TITLE
Removing ripple effect from close & submit

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -538,7 +538,7 @@
                                         </div> 
 
                                         <div class="mdl-card__actions mdl-card--border">
-                                            <button class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+                                            <button class="mdl-button mdl-button--colored mdl-js-button">
                                                 Submit
                                             </button>
                                         </div>
@@ -548,7 +548,7 @@
                                     <span id="js-form-response" class="mdl-chip__text"></span>
                                 </span>
                                 <div class="mdl-card__menu">
-                                    <button class="mdl-button mdl-button--icon mdl-js-button mdl-js-ripple-effect mdl-custom-close">
+                                    <button class="mdl-button mdl-button--icon mdl-js-button mdl-custom-close">
                                       <span class="material-icons">close</span>
                                     </button>
                                 </div>


### PR DESCRIPTION
Because apparently iOS makes you double tap with animations.